### PR TITLE
G2P-5581 remove obsolete openg2p-fastapi-partner-auth module and introduce centralized crypto/key management

### DIFF
--- a/openg2p-fastapi-common/pyproject.toml
+++ b/openg2p-fastapi-common/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
   "json-logging >=1.3.0",
   "orjson >=3.9.7",
   "PyJWT[crypto] >=2.8.0",
+  "novu-py==3.19.0",
 ]
 dynamic = ["version"]
 

--- a/openg2p-fastapi-common/src/openg2p_fastapi_common/config.py
+++ b/openg2p-fastapi-common/src/openg2p_fastapi_common/config.py
@@ -147,6 +147,11 @@ class Settings(BaseSettings):
     # HTTP timeout (s) for a key fetch from PM.
     partner_key_fetch_timeout_seconds: float = 3.0
 
+    # Notification / Novu. Each service reads these with its own env prefix.
+    notification_impl: str = "openg2p_fastapi_common.notification.implementations.NovuNotifier"
+    novu_url: str = "https://api.novu.co"
+    novu_api_key: str = ""
+
     cors_allow_origins: List[str] = []
     cors_allow_credentials: bool = True
     security_headers_enabled: bool = True

--- a/openg2p-fastapi-common/src/openg2p_fastapi_common/notification/__init__.py
+++ b/openg2p-fastapi-common/src/openg2p_fastapi_common/notification/__init__.py
@@ -1,0 +1,3 @@
+from .factory import NotificationFactory
+from .interface import NotificationInterface
+from .models import NotificationResponse, NotificationResponseStatus, Recipient

--- a/openg2p-fastapi-common/src/openg2p_fastapi_common/notification/app.py
+++ b/openg2p-fastapi-common/src/openg2p_fastapi_common/notification/app.py
@@ -1,0 +1,15 @@
+# ruff: noqa: E402
+
+
+from ..app import Initializer as BaseInitializer
+from ..config import Settings
+from .config import load_impl
+from .factory import NotificationFactory
+
+_config = Settings.get_config(strict=False)
+
+
+class Initializer(BaseInitializer):
+    def initialize(self, **kwargs):
+        NotificationFactory()
+        load_impl(_config.notification_impl)()

--- a/openg2p-fastapi-common/src/openg2p_fastapi_common/notification/config.py
+++ b/openg2p-fastapi-common/src/openg2p_fastapi_common/notification/config.py
@@ -1,0 +1,7 @@
+import importlib
+
+
+def load_impl(dotted_path: str):
+    """Import 'pkg.module.ClassName' and return the class (config-driven selection)."""
+    module_path, _, class_name = dotted_path.rpartition(".")
+    return getattr(importlib.import_module(module_path), class_name)

--- a/openg2p-fastapi-common/src/openg2p_fastapi_common/notification/factory/__init__.py
+++ b/openg2p-fastapi-common/src/openg2p_fastapi_common/notification/factory/__init__.py
@@ -1,0 +1,1 @@
+from .notification_factory import NotificationFactory

--- a/openg2p-fastapi-common/src/openg2p_fastapi_common/notification/factory/notification_factory.py
+++ b/openg2p-fastapi-common/src/openg2p_fastapi_common/notification/factory/notification_factory.py
@@ -1,0 +1,10 @@
+from ...service import BaseService
+from ..interface.notification_interface import NotificationInterface
+
+
+class NotificationFactory(BaseService):
+    @staticmethod
+    def get_notifier() -> NotificationInterface:
+        # Whichever NotificationInterface impl the Initializer registered
+        # (selected by Settings.impl).
+        return NotificationInterface.get_component()

--- a/openg2p-fastapi-common/src/openg2p_fastapi_common/notification/implementations/__init__.py
+++ b/openg2p-fastapi-common/src/openg2p_fastapi_common/notification/implementations/__init__.py
@@ -1,0 +1,1 @@
+from .novu_notifier import NovuNotifier

--- a/openg2p-fastapi-common/src/openg2p_fastapi_common/notification/implementations/novu_notifier.py
+++ b/openg2p-fastapi-common/src/openg2p_fastapi_common/notification/implementations/novu_notifier.py
@@ -1,0 +1,53 @@
+import logging
+from typing import Any
+
+import novu_py
+from novu_py import Novu
+
+from ...config import Settings
+from ..interface.notification_interface import NotificationInterface
+from ..models import (
+    NotificationResponse,
+    NotificationResponseStatus,
+    Recipient,
+)
+
+_config = Settings.get_config(strict=False)
+_logger = logging.getLogger("novu_notifier_impl")
+
+
+class NovuNotifier(NotificationInterface):
+    def send_notification(
+        self,
+        notification_id: str,
+        payload: Any,
+        workflow_id: str,
+        recipient: Recipient,
+    ) -> NotificationResponse:
+        if not workflow_id:
+            raise ValueError("workflow_id is required")
+
+        with Novu(server_url=_config.novu_url, secret_key=_config.novu_api_key) as novu:
+            _logger.info(
+                f"Sending notification with ID {notification_id} to {recipient.recipient_email} via Novu"
+            )
+            _logger.info(f"Using workflow ID: {workflow_id}")
+            novu_response = novu.trigger(
+                trigger_event_request_dto=novu_py.TriggerEventRequestDto(
+                    workflow_id=workflow_id,
+                    payload=payload or {},
+                    overrides=novu_py.Overrides(),
+                    to=recipient.recipient_email or recipient.recipient_id,
+                )
+            )
+            _logger.info(f"Novu response: {novu_response.result}")
+            notification_response = NotificationResponse(
+                notification_id=notification_id,
+                response=str(novu_response.result),
+                status=(
+                    NotificationResponseStatus.SUCCESS
+                    if novu_response.result.status.value == "processed"
+                    else NotificationResponseStatus.FAILURE
+                ),
+            )
+            return notification_response

--- a/openg2p-fastapi-common/src/openg2p_fastapi_common/notification/interface/__init__.py
+++ b/openg2p-fastapi-common/src/openg2p_fastapi_common/notification/interface/__init__.py
@@ -1,0 +1,1 @@
+from .notification_interface import NotificationInterface

--- a/openg2p-fastapi-common/src/openg2p_fastapi_common/notification/interface/notification_interface.py
+++ b/openg2p-fastapi-common/src/openg2p_fastapi_common/notification/interface/notification_interface.py
@@ -1,0 +1,18 @@
+from typing import Any
+
+from ...service import BaseService
+from ..models import Recipient
+
+
+class NotificationInterface(BaseService):
+    def send_notification(
+        self,
+        notification_id: str,
+        payload: Any,
+        workflow_id: str,
+        recipient: Recipient,
+    ) -> None:
+        """
+        Send a notification using the given Novu workflow identifier.
+        """
+        pass

--- a/openg2p-fastapi-common/src/openg2p_fastapi_common/notification/models/__init__.py
+++ b/openg2p-fastapi-common/src/openg2p_fastapi_common/notification/models/__init__.py
@@ -1,0 +1,5 @@
+from .notifications import (
+    NotificationResponse,
+    NotificationResponseStatus,
+)
+from .recipient import Recipient

--- a/openg2p-fastapi-common/src/openg2p_fastapi_common/notification/models/notifications.py
+++ b/openg2p-fastapi-common/src/openg2p_fastapi_common/notification/models/notifications.py
@@ -1,0 +1,15 @@
+import enum
+from typing import Optional
+
+from pydantic import BaseModel
+
+
+class NotificationResponseStatus(enum.Enum):
+    SUCCESS = "SUCCESS"
+    FAILURE = "FAILURE"
+
+
+class NotificationResponse(BaseModel):
+    notification_id: str
+    response: Optional[str] = None
+    status: NotificationResponseStatus

--- a/openg2p-fastapi-common/src/openg2p_fastapi_common/notification/models/recipient.py
+++ b/openg2p-fastapi-common/src/openg2p_fastapi_common/notification/models/recipient.py
@@ -1,0 +1,10 @@
+from typing import Optional
+
+from pydantic import BaseModel
+
+
+class Recipient(BaseModel):
+    recipient_id: str
+    recipient_name: Optional[str] = None
+    recipient_email: Optional[str] = None
+    recipient_phone: Optional[str] = None


### PR DESCRIPTION
Recreated from GitLab MR openg2p/shared-libraries/fastapi-common!68 (author: @vin0dkhichar) as part of the GitLab -> GitHub migration.

Original MR: https://gitlab.com/openg2p/shared-libraries/fastapi-common/-/merge_requests/68
Original source: vin0dkhichar/fastapi-common @ 1.2 (fork)
Head commit carried over unchanged: 0a2bc128

Note: the MR title above is the one carried from GitLab; the commit on the branch is "G2P-5602 Add Novu notification implementation and related configurations" (14 files, +145). Please retitle if the GitLab title was stale.

The fork no longer exists on GitHub, so the branch was pushed into this repo to preserve the change. Authorship on the commit is unchanged.